### PR TITLE
Ignore positions with null latitude and longitude.

### DIFF
--- a/api-server/BufferingWritableStream.ts
+++ b/api-server/BufferingWritableStream.ts
@@ -61,6 +61,7 @@ export default class BufferingWritableStream<T> extends Writable {
   doFlushBuffer(buffer: T[], done: Callback) {
     const output = this.createNewOutput((err?: Error) => {
       if (err) {
+        console.error(err)
         setTimeout(
           () => this.doFlushBuffer(buffer, done),
           this.retryInterval.toMillis()

--- a/api-server/domain/Trackpoint.ts
+++ b/api-server/domain/Trackpoint.ts
@@ -112,7 +112,12 @@ export class TrackpointsToClickHouseTSV extends Transform {
   }
 
   _transform(trackpoint: Trackpoint, encoding: string, cb: TransformCallback) {
-    this.push(trackPointToColumns(trackpoint))
+    if (
+      trackpoint.coords.latitude != null &&
+      trackpoint.coords.longitude != null
+    ) {
+      this.push(trackPointToColumns(trackpoint))
+    }
     cb()
   }
 }


### PR DESCRIPTION
Real world Signal K data may have positions with null latitude and longitude.
Also include values with nulls in the test data. These are included as first
elements, where a failed attempt to insert to Clickhouse stops the stream.

Also change logging so that errors from Clickhouse streams are logged.

