### PR TITLE
chore: switch to clickhouse/clickhouse-server

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   clickhouse:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:22.3.3-alpine
     ports:
      - 48123:8123
      - 49000:9000


### PR DESCRIPTION
Clickhouse is now an independent company in the US
and no longer associated with Yandex afaik. They
recently started publishing multi-arch images
that include arm64 builds, so usable also on
modern Macs.